### PR TITLE
Refactor routes: Separate getAllPosts and getPostBySenderId into dist…

### DIFF
--- a/controllers/post_controller.js
+++ b/controllers/post_controller.js
@@ -14,7 +14,6 @@ const createPost = async (req, res) => {
   };
 
 const getAllPosts = async (req, res) => {
-    const  senderFilter = req.query.sender;
     try{
       const posts = await postModel.find();
       res.status(200).send(posts);
@@ -25,9 +24,9 @@ const getAllPosts = async (req, res) => {
 };
 
 const getPostBySenderId = async (req,res) => {
-    const sender = req.query.senderId;
+    const {senderId} = req.query;
     try{
-      const postsById = await postModel.find({senderId:sender});
+      const postsById = await postModel.find({senderId: senderId});
       if(postsById.length==0)
       {
         res.status(400).send("No posts found for the given sender ID");

--- a/request.rest
+++ b/request.rest
@@ -26,4 +26,4 @@ Content-Type: application/json
 GET http://localhost:3000/posts
 
 ###
-GET http://localhost:3000/posts?senderId=123456
+GET http://localhost:3000/posts/bySender?senderId=123456

--- a/routes/post_route.js
+++ b/routes/post_route.js
@@ -10,6 +10,6 @@ router.post("/", (req, res) => {
 router.get("/",postsController.getAllPosts);
 
 
-router.get("/", postsController.getPostBySenderId);
+router.get("/bySender", postsController.getPostBySenderId);
 
 module.exports = router;


### PR DESCRIPTION
…inct paths

What does this PR do?
 Refactors the `/posts` routes by separating the `getAllPosts` and `getPostBySenderId` functionalities into distinct paths.
1. `getAllPosts` now handles requests to `/posts`.
2. `getPostBySenderId` now handles requests to `/posts/bySender` 

How to test?
1. Make a request to `/posts` to retrieve all posts.
2. Make a request to `/posts/bySender?senderId=<id>` 
4. Verify that the routes work as expected without conflicts.